### PR TITLE
Added italian translation

### DIFF
--- a/editorconfig.pro
+++ b/editorconfig.pro
@@ -57,4 +57,5 @@ FORMS += \
     editorconfigpage.ui
 
 TRANSLATIONS += \
-    editorconfig_de.ts
+    editorconfig_de.ts \
+    editorconfig_it.ts

--- a/editorconfig_it.ts
+++ b/editorconfig_it.ts
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it_IT">
+<context>
+    <name>EditorConfig</name>
+    <message>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+</context>
+<context>
+    <name>EditorConfig::EditorConfigData</name>
+    <message>
+        <source>override tab width with %1</source>
+        <translation>sostituisci larghezza tab con %1</translation>
+    </message>
+    <message>
+        <source>override indent size with %1</source>
+        <translation>sostituisci larghezza indentazione con %1</translation>
+    </message>
+    <message>
+        <source>override indent style with &apos;tab&apos;</source>
+        <translation>sostituisci stile indentazione con &apos;tab&apos;</translation>
+    </message>
+    <message>
+        <source>override indent style with &apos;space&apos;</source>
+        <translation>sostituisci stile indentazione con &apos;spazio&apos;</translation>
+    </message>
+    <message>
+        <source>override add final newline with &apos;true&apos;</source>
+        <translation>imposta aggiunta nuova riga finale con &apos;true&apos;</translation>
+    </message>
+    <message>
+        <source>override add final newline with &apos;false&apos;</source>
+        <translation>imposta aggiunta nuova riga finale con &apos;false&apos;</translation>
+    </message>
+    <message>
+        <source>override trim trailing whitespace with &apos;true&apos;</source>
+        <translation>imposta rimozione spazi finali con &apos;true&apos;</translation>
+    </message>
+    <message>
+        <source>override trim trailing whitespace with &apos;false&apos;</source>
+        <translation>imposta rimozione spazi finali con &apos;false&apos;</translation>
+    </message>
+    <message>
+        <source>override charset with &apos;%1&apos;</source>
+        <translation>imposta set caratteri con &apos;%1&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>EditorConfig::EditorConfigDialog</name>
+    <message>
+        <source>Editorconfig File</source>
+        <translation>Editorconfig File</translation>
+    </message>
+</context>
+<context>
+    <name>EditorConfig::EditorConfigPage</name>
+    <message>
+        <source>Editorconfig Details</source>
+        <translation>Editorconfig Dettagli</translation>
+    </message>
+</context>
+<context>
+    <name>EditorConfig::EditorConfigWizard</name>
+    <message>
+        <source>Editorconfig File</source>
+        <translation>Editorconfig File</translation>
+    </message>
+    <message>
+        <source>Creates an initial editorconfig file derived from the current C++, Qml and generic files settings.</source>
+        <translation>Crea un file editorconfig partendo dalle impostazioni dei file C++, Qml e generici in uso.</translation>
+    </message>
+</context>
+<context>
+    <name>EditorConfigPage</name>
+    <message>
+        <source>Path</source>
+        <translation>Percorso</translation>
+    </message>
+    <message>
+        <source>Path:</source>
+        <translation>Percorso:</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
A small contribution, it should be fine as is.

I noticed that QLinguist has set a '%1' at line 46 of the translation, where in the german translation is set as '%2' (I was started from a clean empty translation, all the contexts were added by QLinguist); I'm not sure if this is correct or it should be changed in this translation or in the german one, where it is unfinished, so it seems not to be a problem, I just wanted to make it notice.

There are also a pair of translations that seems need to be fixed in the `editorconfigpage.ui`:
- The window name 'Form' can be removed
- The 'Path:' label seems to have unwanted html tags, can those be removed as well or am I missing something?
