### PR TITLE
Add CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_qtc_plugin(EditorConfig
+  DEPENDS editorconfig
+  PLUGIN_DEPENDS Core TextEditor ProjectExplorer
+  SOURCES
+    editorconfig_global.h editorconfigconstants.h
+    editorconfigplugin.cpp editorconfigplugin.h
+    editorconfigdata.cpp editorconfigdata.h
+    editorconfiglogging.cpp editorconfiglogging.h
+    editorconfigwizard.cpp editorconfigwizard.h
+    editorconfigwizardpage.cpp editorconfigwizardpage.h
+    editorconfigwizarddialog.cpp editorconfigwizarddialog.h
+    editorconfigpage.ui
+    editorconfig_de.ts editorconfig_it.ts
+)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ deployment of the plugin.
 
 For building plugins you usually have to build QtCreator yourself. For
 openSUSE the special libqt5-creator-plusgin-devel RPM provided in the
-repository mentioned above caon be used instead.
+repository mentioned above can be used instead.
 
 The environment variables `QTC_SOURCE` shall contain the path to qt-creators
 source, `QTC_BUILD` to it's build folder. Now run


### PR DESCRIPTION
Now, qtcreator has been built with cmake. It's time to add cmake build system.
issue: #8